### PR TITLE
bugfix inventor

### DIFF
--- a/src/main/java/philosophers_ice/Inventory.java
+++ b/src/main/java/philosophers_ice/Inventory.java
@@ -183,7 +183,7 @@ public class Inventory implements Serializable {
     }
 
     public int getMaxSize() {
-        return maxSize += (p1.str * 2);
+        return maxSize + (p1.str * 2);
     }
 }
 


### PR DESCRIPTION
bugfix: getMaxSize doesn't increase the size of the inventory by your strength.